### PR TITLE
Feature backend swagger

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
 	//swagger-ui
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
-	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '3.0.0'
 
 	//springboot validation
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'

--- a/backend/src/main/java/com/hummingbird/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hummingbird/backend/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.hummingbird.backend.common.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -11,6 +12,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 @EnableWebSecurity // Spring Security를 활성화한다는 의미의 어노테이션
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    public void configure(WebSecurity web) throws Exception{
+        web.ignoring().antMatchers("/static/css/**", "/static/js/**", "*.ico"); // 나중에 수정
+
+        // swagger
+        web.ignoring().antMatchers(
+                "/v2/api-docs", "/configuration/ui", "/swagger-resources",
+                "/configuration/security", "/swagger-ui.html", "/webjars/**","/swagger/**");
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/backend/src/main/java/com/hummingbird/backend/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/hummingbird/backend/common/config/SwaggerConfig.java
@@ -1,13 +1,17 @@
 package com.hummingbird.backend.common.config;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+@Configuration
+@EnableSwagger2
 public class SwaggerConfig {
     @Bean
     public Docket restAPI(){


### PR DESCRIPTION
swagger setting 완료


spring 2.6.부터는 기본 전략이 mvcMatchers 전략이 변경 되어 spring security에서 web.ignore로 swagger 설정하기 위해서는 spring.mvc.pathmatch.matching-strategy 전략을 ant-path-matcher로 바꿔줘야한다.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes

If you are using Spring Security, you should review your use of mvcMatchers to ensure that your matchers continue to meet your needs. With AntPathMatcher, authorizeRequests.mvcMatchers("hello").permitAll() would grant access to /hello. The more precise matching of PathPatternParser requires the use of authorizeRequests.mvcMatchers("/hello").permitAll() (note the leading /) instead.

If you need to switch the default back to AntPathMatcher, you can set spring.mvc.pathmatch.matching-strategy to ant-path-matcher.

spring:
  mvc:
    pathmatch:
      matching-strategy: ant_path_matcher