### PR TITLE
이미지 업로드 및 불러오기

### DIFF
--- a/backend/src/main/java/com/hummingbird/backend/common/config/WebConfig.java
+++ b/backend/src/main/java/com/hummingbird/backend/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.hummingbird.backend.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private String connectPath = "/images/**";
+
+    private String resourcePath = "file:////usr/src/backend/files/";
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(connectPath)
+                .addResourceLocations(resourcePath);
+    }
+}

--- a/backend/src/main/java/com/hummingbird/backend/food/service/serviceImpl/FoodServiceImpl.java
+++ b/backend/src/main/java/com/hummingbird/backend/food/service/serviceImpl/FoodServiceImpl.java
@@ -11,6 +11,7 @@ import com.hummingbird.backend.food.repository.FoodRepository;
 import com.hummingbird.backend.food.service.FoodService;
 import com.hummingbird.backend.util.MD5Generator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,27 +36,30 @@ public class FoodServiceImpl implements FoodService {
 
     //files
     @Override
-    public UploadFoodDto upload(MultipartFile files){
+    public UploadFoodDto upload(MultipartFile file){
         String name = null;
         String savePath= null;
         String path = null;
         String origName = null;
 
         try {
-            origName = files.getOriginalFilename();
-            name = new MD5Generator(origName).toString();
-            savePath = System.getProperty("user.dir") +File.separator+ "files";
+            origName = file.getOriginalFilename();
+            name = new MD5Generator(origName).toString()+origName;
+//            name=origName;
+            savePath="/usr/src/backend/files";
 
             /* 파일이 저장되는 폴더가 없으면 폴더를 생성합니다. */
             if (!new java.io.File(savePath).exists()) {
                 try {
                     new java.io.File(savePath).mkdir();
+                    System.out.println("mkdir");
                 } catch (Exception e) {
                     e.getStackTrace();
                 }
             }
             path = savePath + File.separator + name;
-            files.transferTo(new java.io.File(path));
+            file.transferTo(new java.io.File(path));
+            System.out.println("transfer");
 
         }  catch (Exception e) {
             e.printStackTrace();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./frontend:/usr/src/app
+      - ./menu-canvas:/usr/src/front
       - /usr/src/app/node_modules
       - /usr/src/app/.next
     networks:
@@ -25,7 +25,7 @@ services:
     environment:
       spring.datasource.url: "jdbc:mysql://mysqldb:3306/test_db?useSSL=false&useLegacyDatetimeCode=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&autoReconnect=true&createDatabaseIfNotExist=true"
     volumes:
-      - ./backend:/backend
+      - ./menu-canvas:/usr/src/backend
     networks:
       - network-tier
     tty: true
@@ -44,7 +44,7 @@ services:
         "--collation-server=utf8mb4_unicode_ci",
       ]
     volumes:
-      - mysql-data:/var/lib/menucanvas
+      - ./menu-canvas:/usr/src/db
     ports:
       - "3306:3306"
 
@@ -57,4 +57,4 @@ networks:
     external: true
 
 volumes:
-  mysql-data:
+  menu-canvas:


### PR DESCRIPTION
리소스 핸들러를 추가하여 images/**로 파일에 접근할 수 있도록 수정했습니다.
파일 업로드는 기존의 md5 이름으로는 이미지가 다운로드만 되고 보여줄 수 없어서 md5에 origName을 추가하여 파일 이름 중복은 제거하고 바로 볼 수는 있도록 하였습니다.
프론트와 백엔드 컨테이너가 볼륨을 공유하여 업로드된 파일에 둘 다 접근할 수 있도록 수정했습니다.