### PR TITLE
장바구니 수량 더하기 빼기 및 장바구니 삭제 기능 구현

### DIFF
--- a/frontend/components/AdminMenu/AdminMenu.tsx
+++ b/frontend/components/AdminMenu/AdminMenu.tsx
@@ -16,7 +16,6 @@ type Props = {
 
 const AdminMenu = ({ menuList }: Props) => {
   const [modalOpen, setModalOpen] = useState(false);
-  console.log(menuList);
   return (
     <div>
       <S.HeaderWrap>
@@ -28,7 +27,9 @@ const AdminMenu = ({ menuList }: Props) => {
       <S.MenuContent>
         {menuList &&
           menuList.map(({ id, name }) => (
-            <MenuCard key={id} menuId={id} menuName={name} />
+            <div className="MenuCard__wrapper" key={id}>
+              <MenuCard menuId={id} menuName={name} />
+            </div>
           ))}
       </S.MenuContent>
       {modalOpen && <MenuModal setModalOpen={setModalOpen} type="메뉴판" />}

--- a/frontend/components/AdminMenu/style.tsx
+++ b/frontend/components/AdminMenu/style.tsx
@@ -19,5 +19,12 @@ export const HeaderTitle = styled.h2`
 `;
 
 export const MenuContent = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   padding: 50px 10px;
+
+  .MenuCard__wrapper {
+    margin: 30px;
+  }
 `;

--- a/frontend/components/Banner.tsx
+++ b/frontend/components/Banner.tsx
@@ -10,27 +10,29 @@ const Banner = () => {
 
   return (
     <Themediv>
-
-        <ThemeSection>
-          <Subdiv>OrderCanvas 오더 캔버스</Subdiv>
-          <StyledH1>앱을 다운 로드 받을 필요 없이<br/> QR 하나로 주문까지!</StyledH1>
-          <StyledDesc>지금 바로 스마트 메뉴판을 만들어보세요.</StyledDesc>
-          <StyledBtn onClick={() => router.push("/menupage")}>
-            메뉴만들기
-          </StyledBtn>
-          <StyledTwoPhone/>
-        </ThemeSection>
+      <ThemeSection>
+        <Subdiv>OrderCanvas 오더 캔버스</Subdiv>
+        <StyledH1>
+          앱을 다운 로드 받을 필요 없이
+          <br /> QR 하나로 주문까지!
+        </StyledH1>
+        <StyledDesc>지금 바로 스마트 메뉴판을 만들어보세요.</StyledDesc>
+        <StyledBtn onClick={() => router.push("/mypage/1")}>
+          메뉴만들기
+        </StyledBtn>
+        <StyledTwoPhone />
+      </ThemeSection>
     </Themediv>
   );
 };
 
 const Themediv = styled.div`
-    display: flex;
-    justify-items: center;
-    height: 550px;
-    text-align:center;
-    color: white;
-    line-height:1.5;
+  display: flex;
+  justify-items: center;
+  height: 550px;
+  text-align: center;
+  color: white;
+  line-height: 1.5;
 `;
 
 const ThemeSection = styled.div`

--- a/frontend/components/CartItem/CartItem.tsx
+++ b/frontend/components/CartItem/CartItem.tsx
@@ -3,6 +3,8 @@ import Image from "next/image";
 
 import * as S from "./style";
 import { numberFormat } from "../../utils/numberFormat";
+import { useRecoilState } from "recoil";
+import { CartItemState } from "../../recoil/states";
 
 type Props = {
   foodId: number;
@@ -13,6 +15,26 @@ type Props = {
 };
 
 const CartItem = ({ foodId, foodName, foodPrice, count, fileName }: Props) => {
+  const [cartItem, setCartItem] = useRecoilState(CartItemState);
+  const CartItemCount = (countNum: number) => {
+    setCartItem((cartItem) => {
+      return cartItem.map((item) =>
+        item.foodId === foodId
+          ? {
+              foodId: foodId,
+              fileName: fileName,
+              foodName: foodName,
+              foodPrice: foodPrice,
+              count:
+                item.count + countNum !== 0
+                  ? item.count + countNum
+                  : item.count,
+            }
+          : item
+      );
+    });
+  };
+
   return (
     <S.ItemWrap key={foodId}>
       <Image
@@ -28,9 +50,9 @@ const CartItem = ({ foodId, foodName, foodPrice, count, fileName }: Props) => {
           <S.PriceText>{numberFormat(foodPrice)} 원</S.PriceText>
           <S.CountBtn>
             <p>
-              <button>+</button>
+              <button onClick={() => CartItemCount(1)}>+</button>
               {count}
-              <button>-</button>
+              <button onClick={() => CartItemCount(-1)}>-</button>
             </p>
           </S.CountBtn>
         </S.FoodPrice>

--- a/frontend/components/CartItem/CartItem.tsx
+++ b/frontend/components/CartItem/CartItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import Image from "next/image";
 
 import * as S from "./style";
@@ -16,6 +16,7 @@ type Props = {
 
 const CartItem = ({ foodId, foodName, foodPrice, count, fileName }: Props) => {
   const [cartItem, setCartItem] = useRecoilState(CartItemState);
+  const [dropDownOpen, setDropDownOpen] = useState<boolean>(false);
   const CartItemCount = (countNum: number) => {
     setCartItem((cartItem) => {
       return cartItem.map((item) =>
@@ -35,6 +36,12 @@ const CartItem = ({ foodId, foodName, foodPrice, count, fileName }: Props) => {
     });
   };
 
+  const deleteCartItem = () => {
+    setCartItem((cartItem) => {
+      return cartItem.filter((item) => item.foodId !== foodId);
+    });
+  };
+
   return (
     <S.ItemWrap key={foodId}>
       <Image
@@ -42,6 +49,7 @@ const CartItem = ({ foodId, foodName, foodPrice, count, fileName }: Props) => {
         alt="음식 사진"
         width="100"
         height="100"
+        layout="fixed"
         unoptimized={true}
       />
       <S.ContentWrap>
@@ -56,6 +64,17 @@ const CartItem = ({ foodId, foodName, foodPrice, count, fileName }: Props) => {
             </p>
           </S.CountBtn>
         </S.FoodPrice>
+        <button onClick={() => setDropDownOpen(!dropDownOpen)}>
+          <S.MoreBtn />
+        </button>
+        {dropDownOpen && (
+          <S.Dropdown>
+            <ul>
+              <li>찜 목록 추가하기</li>
+              <li onClick={deleteCartItem}>삭제하기</li>
+            </ul>
+          </S.Dropdown>
+        )}
       </S.ContentWrap>
     </S.ItemWrap>
   );

--- a/frontend/components/CartItem/style.tsx
+++ b/frontend/components/CartItem/style.tsx
@@ -1,19 +1,21 @@
 import styled from "styled-components";
-
+import { FiMoreVertical } from "react-icons/fi";
 export const ItemWrap = styled.div`
   display: flex;
   margin-top: 24px;
   background-color: #fff;
   padding: 15px;
   border-radius: 20px;
-  box-sizing: content-box;
 
   img {
     border-radius: 50%;
+    max-width: 100px;
+    max-height: 100px;
   }
 `;
 
 export const ContentWrap = styled.div`
+  position: relative;
   padding: 20px;
   flex: 1;
   h3 {
@@ -44,6 +46,40 @@ export const CountBtn = styled.div`
       font-weight: 600;
       cursor: pointer;
       box-sizing: content-box;
+    }
+  }
+`;
+
+export const MoreBtn = styled(FiMoreVertical)`
+  position: absolute;
+  top: 8px;
+  right: 0;
+  font-size: 1.2rem;
+  color: gray;
+  cursor: pointer;
+`;
+
+export const Dropdown = styled.div`
+  position: absolute;
+  top: 40px;
+  right: 6px;
+  background-color: #fff;
+  border: 1px solid gray;
+  border-radius: 10px;
+
+  li {
+    padding: 10px;
+    :hover {
+      cursor: pointer;
+      background-color: var(--color-orange);
+      color: white;
+    }
+    :first-child {
+      border-bottom: 1px solid gray;
+      border-radius: 10px 10px 0px 0px;
+    }
+    :last-child {
+      border-radius: 0px 0px 10px 10px;
     }
   }
 `;

--- a/frontend/components/FoodCard/FoodCard.tsx
+++ b/frontend/components/FoodCard/FoodCard.tsx
@@ -37,6 +37,7 @@ const FoodCard = ({ foodList }: Props) => {
               alt="음식 사진"
               width="64"
               height="64"
+              layout="fixed"
               unoptimized={true}
             />
             <div className="foodcard_top__content">

--- a/frontend/components/FoodCard/FoodCard.tsx
+++ b/frontend/components/FoodCard/FoodCard.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 
 import * as S from "./style";
 import MenuModal from "../MenuModal";
+import { numberFormat } from "../../utils/numberFormat";
 type FoodData = {
   content: string;
   fileName: string;
@@ -45,12 +46,9 @@ const FoodCard = ({ foodList }: Props) => {
               <ul className="foodcard_top__list">
                 <li>
                   <span>가격</span>
-                  {price}
+                  {numberFormat(price)}
                 </li>
-                <li>
-                  <span>알레르기 정보</span>
-                  연어, 토마토
-                </li>
+                <li></li>
               </ul>
             </div>
           </div>

--- a/frontend/components/FoodCard/style.tsx
+++ b/frontend/components/FoodCard/style.tsx
@@ -27,7 +27,8 @@ export const FoodItem = styled.div`
   .foodcard-top {
     display: flex;
   }
-  Image {
+  img {
+    border-radius: 50%;
   }
 
   .foodcard_top__content {

--- a/frontend/components/FoodMenuItem/FoodMenuItem.tsx
+++ b/frontend/components/FoodMenuItem/FoodMenuItem.tsx
@@ -80,6 +80,7 @@ const FoodMenuItem = ({
             alt="음식 사진"
             width="128"
             height="128"
+            layout="fixed"
             unoptimized={true}
           />
         </li>

--- a/frontend/components/FoodMenuItem/FoodMenuItem.tsx
+++ b/frontend/components/FoodMenuItem/FoodMenuItem.tsx
@@ -56,10 +56,6 @@ const FoodMenuItem = ({
     []
   );
 
-  useEffect(() => {
-    console.log(cartItem);
-  }, [cartItem]);
-
   const handleAddCart = (
     admin: boolean,
     idx: number,

--- a/frontend/components/MenuCard/style.tsx
+++ b/frontend/components/MenuCard/style.tsx
@@ -13,6 +13,7 @@ export const CardWrap = styled.div`
 export const CardTitle = styled.li`
   font-weight: 700;
   font-size: 1.75rem;
+  line-height: 2rem;
   padding-bottom: 10px;
   h2 {
     background: linear-gradient(to right, #f32170, #ff6b08, #cf23cf, #eedd44);

--- a/frontend/components/MenuModal/MenuUpdateForm.tsx
+++ b/frontend/components/MenuModal/MenuUpdateForm.tsx
@@ -17,10 +17,11 @@ const MenuUpdateForm = ({ setModalOpen, menuId, menuName }: Props) => {
 
   const updateMenu = async (updateName: string, menuId: number) => {
     try {
+      console.log(updateName);
       const response = await axios.post(
         "http://localhost:8080/menu/update",
         {
-          updateName: updateName,
+          menuName: updateName,
           menuId: String(menuId),
         },
         {
@@ -39,7 +40,6 @@ const MenuUpdateForm = ({ setModalOpen, menuId, menuName }: Props) => {
   };
 
   const handleMenuChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log(e.target.value);
     setEditMenuName(e.target.value);
   };
   const handleUpdateMenuSubmit = (e: React.FormEvent<HTMLElement>) => {

--- a/frontend/pages/paypage.tsx
+++ b/frontend/pages/paypage.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import React from "react";
-import Payment from '../components/Payment'
+// import Payment from '../components/Payment'
 
 const PayPage: NextPage = () => {
-    return <Payment/>;
+  return <div></div>;
 };
 
 export default PayPage;


### PR DESCRIPTION
개요
- 제목과 동일합니다. 

구현 내용
- 장바구니에 담은 음식에 대하여 추가적으로 수량을 더하거나 뺄 수 있습니다. 
- 장바구니 내 음식의 갯수는 1 이하로 내려가지 않도록 하였습니다. (양수에 대해선 테스트를 아직 안함 돈 많이 벌면 좋지 않을까? 💰) -> 이후 100개 이상 주문 못하도록 추가 구현 할 예정 
- 기획 단계에서는 음식을 좌우 스와이핑을 통하여 장바구니에 추가 혹은 찜하기를 할 수 있었는데 RN에선 쉽게 구현이 가능한 내용이라 쉬울 줄 알았으나 생각보다 React에선 어려워서 일단 더보기 버튼을 구현하여 삭제와 찜기능을 구현하였습니다. 
- 글자수가 많아질 경우 사진이 아래로 길게 늘어나는 현상 수정

스크린샷
<img width="370" alt="image" src="https://user-images.githubusercontent.com/54930877/165557427-c67d49d9-4f86-4cbb-8e01-253dbeea8356.png">
<img width="368" alt="image" src="https://user-images.githubusercontent.com/54930877/165557502-775074f7-f545-4118-af49-e2901907b081.png">
