### PR TITLE
주문 내역건 조회 페이지 마크업

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,74 @@
+{
+  "orderInfoList": [
+    {
+      "orderDate": "2022-05-03T12:05:25.687Z",
+      "orderId": 1,
+      "orderItemList": [
+        {
+          "count": 1,
+          "fileName": "",
+          "foodId": 1,
+          "foodName": "테스트음식 1",
+          "foodPrice": 5000
+        }
+      ],
+      "orderStatus": "ACCEPT"
+    },
+    {
+      "orderDate": "2022-05-03T12:05:25.687Z",
+      "orderId": 2,
+      "orderItemList": [
+        {
+          "count": 2,
+          "fileName": "",
+          "foodId": 2,
+          "foodName": "테스트음식 2",
+          "foodPrice": 5000
+        }
+      ],
+      "orderStatus": "ACCEPT"
+    },
+    {
+      "orderDate": "2022-05-03T12:05:25.687Z",
+      "orderId": 3,
+      "orderItemList": [
+        {
+          "count": 1,
+          "fileName": "",
+          "foodId": 3,
+          "foodName": "테스트음식 3",
+          "foodPrice": 5000
+        }
+      ],
+      "orderStatus": "ACCEPT"
+    },
+    {
+      "orderDate": "2022-05-03T12:05:25.687Z",
+      "orderId": 4,
+      "orderItemList": [
+        {
+          "count": 1,
+          "fileName": "",
+          "foodId": 4,
+          "foodName": "테스트음식 4",
+          "foodPrice": 5000
+        }
+      ],
+      "orderStatus": "ACCEPT"
+    },
+    {
+      "orderDate": "2022-05-03T12:05:25.687Z",
+      "orderId": 5,
+      "orderItemList": [
+        {
+          "count": 2,
+          "fileName": "",
+          "foodId": 5,
+          "foodName": "테스트음식 5",
+          "foodPrice": 5000
+        }
+      ],
+      "orderStatus": "ACCEPT"
+    }
+  ]
+}

--- a/frontend/components/OrderPage/Item.tsx/Item.style.ts
+++ b/frontend/components/OrderPage/Item.tsx/Item.style.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const Wrap = styled.div`
+  display: inline-block;
+  background-color: ${(props) => props.color};
+  margin: 0 auto;
+  width: 100px;
+  height: 20px;
+  border-radius: 10px;
+`;
+
+export const Text = styled.p`
+  text-align: left;
+  padding-left: 10px;
+  padding-top: 2px;
+  span {
+    font-weight: 900;
+    margin-right: 10px;
+  }
+  color: ${(props) => props.color};
+`;

--- a/frontend/components/OrderPage/Item.tsx/Item.tsx
+++ b/frontend/components/OrderPage/Item.tsx/Item.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { FC } from 'react';
+import * as S from './Item.style';
+type ItemProps = {
+  bgColor: string;
+  textColor: string;
+  content: string;
+};
+const Item: FC<ItemProps> = ({
+  bgColor = 'white',
+  textColor = 'black',
+  content = '',
+}) => {
+  return (
+    <S.Wrap color={bgColor}>
+      <S.Text color={textColor}>
+        <span>&#183;</span>
+        {content}
+      </S.Text>
+    </S.Wrap>
+  );
+};
+
+export default Item;

--- a/frontend/components/OrderPage/Item.tsx/index.ts
+++ b/frontend/components/OrderPage/Item.tsx/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Item';

--- a/frontend/components/OrderPage/OrderInfoBtn/OrderInfo.tsx
+++ b/frontend/components/OrderPage/OrderInfoBtn/OrderInfo.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import * as S from './OrferInfo.style';
+const OrderInfo = () => {
+  return (
+    <button>
+      <S.Text>더보기</S.Text>
+    </button>
+  );
+};
+
+export default OrderInfo;

--- a/frontend/components/OrderPage/OrderInfoBtn/OrferInfo.style.ts
+++ b/frontend/components/OrderPage/OrderInfoBtn/OrferInfo.style.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Text = styled.span`
+  color: gray;
+`;

--- a/frontend/components/OrderPage/OrderInfoBtn/index.ts
+++ b/frontend/components/OrderPage/OrderInfoBtn/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderInfo';

--- a/frontend/components/OrderPage/OrderList/OrderList.style.ts
+++ b/frontend/components/OrderPage/OrderList/OrderList.style.ts
@@ -1,0 +1,1 @@
+import styled from 'styled-components';

--- a/frontend/components/OrderPage/OrderList/OrderList.style.ts
+++ b/frontend/components/OrderPage/OrderList/OrderList.style.ts
@@ -1,1 +1,41 @@
 import styled from 'styled-components';
+
+export const Table = styled.table`
+  margin: 20px;
+  width: calc(100% - 40px);
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px;
+  border-radius: 20px;
+
+  tr,
+  td,
+  th {
+    padding: 20px;
+  }
+
+  td {
+    :first-child {
+      font-weight: 600;
+    }
+  }
+
+  tr {
+    text-align: center;
+    border-bottom: 1px solid var(--color-gray);
+    :last-child {
+      border: 0;
+    }
+  }
+
+  th {
+    font-size: 1.125rem;
+    background-color: var(--color-light-gray);
+    color: var(--color-orange);
+    font-weight: 600;
+    :first-child {
+      border-top-left-radius: 20px;
+    }
+    :last-child {
+      border-top-right-radius: 20px;
+    }
+  }
+`;

--- a/frontend/components/OrderPage/OrderList/OrderList.tsx
+++ b/frontend/components/OrderPage/OrderList/OrderList.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import * as S from './OrderList.style';
+import * as D from '../../../data';
+import { useAsync } from '../../../utils/useAsync';
+
+const OrderList = () => {
+  const [orderInfos, setOrderInfos] = useState<D.IOrderInfo[]>([]);
+  const [error, resetError] = useAsync(async () => {
+    setOrderInfos([]);
+    //화면에 보이는 error 문구 제거 함수
+    resetError();
+    // Error 타입 객체가 reject되는 경우 테스트할 시 주석 제거
+    // await Promise.reject(new Error('some error occurs'));
+    const fetchOrderInfos = await D.getOrderInfo();
+    setOrderInfos(fetchOrderInfos);
+  });
+
+  console.log(orderInfos);
+  return <div>OrderList</div>;
+};
+
+export default OrderList;

--- a/frontend/components/OrderPage/OrderList/OrderList.tsx
+++ b/frontend/components/OrderPage/OrderList/OrderList.tsx
@@ -2,7 +2,15 @@ import React, { useState } from 'react';
 import * as S from './OrderList.style';
 import * as D from '../../../data';
 import { useAsync } from '../../../utils/useAsync';
-
+import Item from '../Item.tsx/Item';
+import OrderInfoBtn from '../OrderInfoBtn';
+const menuHeaderList = [
+  '주문 음식 이름',
+  '주문 음식 갯수',
+  '테이블/주문 시각',
+  '주문 상태',
+  '결제 정보',
+];
 const OrderList = () => {
   const [orderInfos, setOrderInfos] = useState<D.IOrderInfo[]>([]);
   const [error, resetError] = useAsync(async () => {
@@ -12,11 +20,58 @@ const OrderList = () => {
     // Error 타입 객체가 reject되는 경우 테스트할 시 주석 제거
     // await Promise.reject(new Error('some error occurs'));
     const fetchOrderInfos = await D.getOrderInfo();
+
     setOrderInfos(fetchOrderInfos);
   });
-
   console.log(orderInfos);
-  return <div>OrderList</div>;
+  return (
+    <S.Table>
+      <thead>
+        <tr>
+          {menuHeaderList.map((header, idx) => (
+            <th key={idx}>{header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {orderInfos.length &&
+          orderInfos.map((val, idx) => (
+            <tr key={idx}>
+              <td>{val.orderItemList.map((val) => val.foodName)}</td>
+              <td className="count">
+                <Item
+                  bgColor={'#f3ecfd'}
+                  textColor={'#8a4af3'}
+                  content={`${String(
+                    val.orderItemList.map((val) => val.count)
+                  )} 개`}
+                />
+              </td>
+              <td>{val.orderDate.substr(11, 5)}</td>
+              {/* TODO : 주문 승인에 대해서 주문 승인 컴포넌트 넣어줄 예정 */}
+              <td>
+                {val.orderStatus === 'ACCEPT' ? (
+                  <Item
+                    bgColor={'#dbefdc'}
+                    textColor={'#357a38'}
+                    content={`주문 승인`}
+                  />
+                ) : (
+                  <Item
+                    bgColor={'#ffeacc'}
+                    textColor={'#995b00'}
+                    content={`주문 취소`}
+                  />
+                )}
+              </td>
+              <td>
+                <OrderInfoBtn />
+              </td>
+            </tr>
+          ))}
+      </tbody>
+    </S.Table>
+  );
 };
 
 export default OrderList;

--- a/frontend/components/OrderPage/OrderList/index.ts
+++ b/frontend/components/OrderPage/OrderList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderList';

--- a/frontend/components/OrderPage/OrderTap/OrderTap.style.ts
+++ b/frontend/components/OrderPage/OrderTap/OrderTap.style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const Tab = styled.ul`
+  display: flex;
+  padding: 20px;
+  border-bottom: 1px solid gray;
+
+  li {
+    margin-right: 20px;
+    font-size: 1.125rem;
+    padding-bottom: 10px;
+  }
+  .tap {
+  }
+  .tap__active {
+    color: var(--color-orange);
+    font-weight: 700;
+  }
+`;

--- a/frontend/components/OrderPage/OrderTap/OrderTap.tsx
+++ b/frontend/components/OrderPage/OrderTap/OrderTap.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import type { FC } from 'react';
+import * as S from './OrderTap.style';
+
+type OrderTapProps = {};
+
+const OrderTap: FC<OrderTapProps> = () => {
+  const TabList = ['모두 보기', '주문 미확인', '주문 확인'];
+  const [selectedTab, SetSelectedTab] = useState<number>(0);
+  return (
+    <S.Tab>
+      {TabList.map((item, index) => (
+        <li
+          className={`${selectedTab === index ? 'tap__active' : 'tap'}`}
+          onClick={() => SetSelectedTab(index)}
+        >
+          <p>{item}</p>
+        </li>
+      ))}
+    </S.Tab>
+  );
+};
+
+export default OrderTap;

--- a/frontend/components/OrderPage/OrderTap/index.ts
+++ b/frontend/components/OrderPage/OrderTap/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderTap';

--- a/frontend/components/PayBtn/PayBtn.tsx
+++ b/frontend/components/PayBtn/PayBtn.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from "react";
-import * as S from "./style";
-import axios from "axios";
-import {stringify} from "json5";
+import React, { useEffect } from 'react';
+import * as S from './style';
+import axios from 'axios';
+import { stringify } from 'json5';
 
 type CartData = {
   fileName: string;
@@ -13,15 +13,14 @@ type CartData = {
 
 type Props = {
   amount: number;
-  itemList : CartData[]
-
+  itemList: CartData[];
 };
 const PayBtn = ({ amount, itemList }: Props) => {
   useEffect(() => {
-    const jquery = document.createElement("script");
-    jquery.src = "https://code.jquery.com/jquery-1.12.4.min.js";
-    const iamport = document.createElement("script");
-    iamport.src = "https://cdn.iamport.kr/js/iamport.payment-1.1.7.js";
+    const jquery = document.createElement('script');
+    jquery.src = 'https://code.jquery.com/jquery-1.12.4.min.js';
+    const iamport = document.createElement('script');
+    iamport.src = 'https://cdn.iamport.kr/js/iamport.payment-1.1.7.js';
     document.head.appendChild(jquery);
     document.head.appendChild(iamport);
     return () => {
@@ -30,27 +29,30 @@ const PayBtn = ({ amount, itemList }: Props) => {
     };
   }, []);
 
-  const createOrder = async (itemList : CartData[],impUid:String,amount:number) => {
+  const createOrder = async (
+    itemList: CartData[],
+    impUid: String,
+    amount: number
+  ) => {
     try {
       console.log(itemList);
       let orderCreateRequest = {
-        "tableNumber":1,
-        "impUid":impUid,
-        "ownerId":1,
-        "cartDataList":itemList,
-        "totalPrice":amount
-      }
-
+        tableNumber: 1,
+        impUid: impUid,
+        ownerId: 1,
+        cartDataList: itemList,
+        totalPrice: amount,
+      };
 
       const response = await axios.post(
-          "http://localhost:8080/api/orders",
-          orderCreateRequest,
-          {
-            headers: {
-              "Access-Control-Allow-Origin": "*",
-              "Content-Type" : "application/json",
-            },
-          }
+        'http://localhost:8080/api/orders',
+        orderCreateRequest,
+        {
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
+          },
+        }
       );
       console.log(response);
       window.location.reload();
@@ -59,22 +61,22 @@ const PayBtn = ({ amount, itemList }: Props) => {
     }
   };
 
-  const onClickPayment = (amount: number, itemList:CartData[]) => {
+  const onClickPayment = (amount: number, itemList: CartData[]) => {
     // @ts-ignore
     const { IMP } = window;
-    IMP.init("imp18788306");
+    IMP.init('imp18788306');
     /* 2. 결제 데이터 정의하기 */
     const data = {
-      pg: "html5_inicis", // PG사
-      pay_method: "card", // 결제수단
+      pg: 'html5_inicis', // PG사
+      pay_method: 'card', // 결제수단
       merchant_uid: `mid_${new Date().getTime()}`, // 주문번호
       amount: amount, // 결제금액
-      name: "아임포트 결제 테스트", // 주문명
-      buyer_name: "홍길동", // 구매자 이름
-      buyer_tel: "01012341234", // 구매자 전화번호
-      buyer_email: "example@example", // 구매자 이메일
-      buyer_addr: "정왕동 661-16", // 구매자 주소
-      buyer_postcode: "06018", // 구매자 우편번호
+      name: '아임포트 결제 테스트', // 주문명
+      buyer_name: '홍길동', // 구매자 이름
+      buyer_tel: '01012341234', // 구매자 전화번호
+      buyer_email: 'example@example', // 구매자 이메일
+      buyer_addr: '정왕동 661-16', // 구매자 주소
+      buyer_postcode: '06018', // 구매자 우편번호
     };
     IMP.request_pay(data, callback);
   };
@@ -90,19 +92,19 @@ const PayBtn = ({ amount, itemList }: Props) => {
       paid_amount,
       status,
     } = response;
-    if (success) {
-      alert("결제 성공");
-      createOrder(itemList,imp_uid,amount)
-      console.log(response);
 
+    if (success) {
+      alert('결제 성공');
+      createOrder(itemList, imp_uid, amount);
+      console.log(response);
     } else {
-      alert("결제 실패 : " + error_msg);
+      alert('결제 실패 : ' + error_msg);
     }
   };
 
   return (
     <>
-      <S.PaymentBtn onClick={() => onClickPayment(amount,itemList)}>
+      <S.PaymentBtn onClick={() => onClickPayment(amount, itemList)}>
         결제하기
       </S.PaymentBtn>
     </>

--- a/frontend/data/IOrderInfo.ts
+++ b/frontend/data/IOrderInfo.ts
@@ -1,0 +1,13 @@
+export type IOrderFood = {
+  count: number;
+  fileName: string;
+  foodName: string;
+  foodPrice: number;
+};
+
+export type IOrderInfo = {
+  orderDate: string;
+  orderId: number;
+  orderItemList: IOrderFood[];
+  orderStatus: string;
+};

--- a/frontend/data/getOrderInfo.ts
+++ b/frontend/data/getOrderInfo.ts
@@ -1,0 +1,14 @@
+import { rejects } from 'assert';
+import axios from 'axios';
+import { resolve } from 'path';
+import { IOrderInfo } from './IOrderInfo';
+
+export const getOrderInfo = (): Promise<IOrderInfo[]> =>
+  new Promise((resolve, reject) => {
+    axios
+      .get('http://localhost:4000/orderInfoList')
+      .then(({ data }) => {
+        resolve(data);
+      })
+      .catch(reject);
+  });

--- a/frontend/data/index.ts
+++ b/frontend/data/index.ts
@@ -1,0 +1,2 @@
+export * from './IOrderInfo';
+export * from './getOrderInfo';

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,9 +1,9 @@
-import Head from "next/head";
-import type { AppProps } from "next/app";
-import { RecoilRoot } from "recoil";
-import { GlobalStyle } from "../styles/global-style";
+import Head from 'next/head';
+import type { AppProps } from 'next/app';
+import { RecoilRoot } from 'recoil';
+import { GlobalStyle } from '../styles/global-style';
 
-import "../styles/globals.css";
+import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,30 +1,30 @@
-import Document, { DocumentContext } from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+import Document, { DocumentContext } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
 export default class MyDocument extends Document {
-    static async getInitialProps(ctx: DocumentContext) {
-        const sheet = new ServerStyleSheet()
-        const originalRenderPage = ctx.renderPage
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
 
-        try {
-            ctx.renderPage = () =>
-                originalRenderPage({
-                    enhanceApp: (App) => (props) =>
-                        sheet.collectStyles(<App {...props} />),
-                })
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        });
 
-            const initialProps = await Document.getInitialProps(ctx)
-            return {
-                ...initialProps,
-                styles: (
-                    <>
-                        {initialProps.styles}
-                        {sheet.getStyleElement()}
-                    </>
-                ),
-            }
-        } finally {
-            sheet.seal()
-        }
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
     }
+  }
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,9 +1,9 @@
-import type { NextPage } from "next";
-import Banner from "../components/Banner";
-import Footer from "../components/Footer";
-import FooterBanner from "../components/FooterBanner";
-import Info from "../components/Info";
-import Nav from "../components/Nav";
+import type { NextPage } from 'next';
+import Banner from '../components/Banner';
+import Footer from '../components/Footer';
+import FooterBanner from '../components/FooterBanner';
+import Info from '../components/Info';
+import Nav from '../components/Nav';
 
 const Home: NextPage = () => {
   return (

--- a/frontend/pages/orderpage.tsx
+++ b/frontend/pages/orderpage.tsx
@@ -1,8 +1,17 @@
-import { NextPage } from "next";
-import React from "react";
+import { NextPage } from 'next';
+import React from 'react';
+import Nav from '../components/Nav';
+import OrderList from '../components/OrderPage/OrderList';
+import OrderTap from '../components/OrderPage/OrderTap';
 
 const OrderPage: NextPage = () => {
-  return <div>orderPage</div>;
+  return (
+    <div>
+      <Nav />
+      <OrderTap />
+      <OrderList />
+    </div>
+  );
 };
 
 export default OrderPage;

--- a/frontend/pages/qrpage.tsx
+++ b/frontend/pages/qrpage.tsx
@@ -1,12 +1,12 @@
-import { NextPage } from "next";
-import { useRouter } from "next/router";
-import React, { useState, useEffect } from "react";
-import QRCode from "react-qr-code";
-import styled from "styled-components";
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import React, { useState, useEffect } from 'react';
+import QRCode from 'react-qr-code';
+import styled from 'styled-components';
 
-import Nav from "../components/Nav";
-import ExViewPhone from "../components/ExViewPhone";
-import ImageNext from "next/image";
+import Nav from '../components/Nav';
+import ExViewPhone from '../components/ExViewPhone';
+import ImageNext from 'next/image';
 
 interface qrpageType {
   queryString: string;
@@ -14,25 +14,25 @@ interface qrpageType {
 }
 
 const QrPage: NextPage = () => {
-  const [url, setUrl] = useState<string>("");
+  const [url, setUrl] = useState<string>('');
   const router = useRouter();
-  const string = "string";
+  const string = 'string';
 
   // QR코드 다운로드 기능
   const onImageDownload = () => {
     // FIXME: useRef를 활용하여 돔 객체에 접근하는 방식이 아닌 State로 접근하는 방식으로 차후 구현할 것.
-    const svg = document.getElementById("QRCode");
+    const svg = document.getElementById('QRCode');
     const svgData = new XMLSerializer().serializeToString(svg!);
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
     const img = new Image();
     img.onload = () => {
       canvas.width = img.width;
       canvas.height = img.height;
       ctx!.drawImage(img, 0, 0);
-      const pngFile = canvas.toDataURL("image/png");
-      const downloadLink = document.createElement("a");
-      downloadLink.download = "QRCode";
+      const pngFile = canvas.toDataURL('image/png');
+      const downloadLink = document.createElement('a');
+      downloadLink.download = 'QRCode';
       downloadLink.href = `${pngFile}`;
       downloadLink.click();
     };
@@ -43,7 +43,7 @@ const QrPage: NextPage = () => {
   useEffect(() => {
     const queryString = String(router.query.menuId);
     const queryStringUrl =
-      "http://localhost:3000/resultmenu?menuId=" + queryString;
+      'http://localhost:3000/resultmenu?menuId=' + queryString;
     console.log(queryStringUrl);
     setUrl(queryStringUrl);
   }, [router.query.menuId]);
@@ -53,21 +53,38 @@ const QrPage: NextPage = () => {
       <Nav />
       <Theme>
         <LeftSection>
-            <StyledH1>앱을 다운 로드 받을 필요 없이<br/>QR 하나로 주문까지!</StyledH1>
-            <StyledDesc>하단 ‘저장 하기’를 누른 후 매장 내잘 보이는 곳에 부착해주세요.</StyledDesc>
-            <StyledList>
-              <StyledItem><CheckBell/>테이블 모서리</StyledItem>
-              <StyledItem><CheckBell/>테이블 위의 작은 팻말</StyledItem>
-              <StyledItem><CheckBell/>웨이팅이 있는 매장 입구</StyledItem>
-            </StyledList>
-            <StyledBtn onClick={() => onImageDownload()}>
-              저장하기
-            </StyledBtn>
+          <StyledH1>
+            앱을 다운 로드 받을 필요 없이
+            <br />
+            QR 하나로 주문까지!
+          </StyledH1>
+          <StyledDesc>
+            하단 ‘저장 하기’를 누른 후 매장 내잘 보이는 곳에 부착해주세요.
+          </StyledDesc>
+          <StyledList>
+            <StyledItem>
+              <CheckBell />
+              테이블 모서리
+            </StyledItem>
+            <StyledItem>
+              <CheckBell />
+              테이블 위의 작은 팻말
+            </StyledItem>
+            <StyledItem>
+              <CheckBell />
+              웨이팅이 있는 매장 입구
+            </StyledItem>
+          </StyledList>
+          <StyledBtn onClick={() => onImageDownload()}>저장하기</StyledBtn>
         </LeftSection>
         <RightSection>
           <SideSection>
             <StyledH2>메뉴 QR 코드</StyledH2>
-            <Desc>핸드폰 카메라로 스캔하시면<br/>메뉴를 보실 수 있습니다.</Desc>
+            <Desc>
+              핸드폰 카메라로 스캔하시면
+              <br />
+              메뉴를 보실 수 있습니다.
+            </Desc>
             <StyledQr>
               {/* FIXME:  영어만 되는 문제점 존재*/}
               <StyledInner>
@@ -75,7 +92,7 @@ const QrPage: NextPage = () => {
               </StyledInner>
             </StyledQr>
           </SideSection>
-          <ExViewPhone/>
+          <ExViewPhone />
         </RightSection>
       </Theme>
     </div>
@@ -86,7 +103,7 @@ const Theme = styled.div`
   display: flex;
   justify-content: center;
   margin: auto;
-  line-height:1.5;
+  line-height: 1.5;
 `;
 
 const LeftSection = styled.div`
@@ -95,14 +112,14 @@ const LeftSection = styled.div`
   text-align: left;
   margin: 5rem 3rem 0rem 3rem;
   background: white;
-  width:"40%";
+  width: '40%';
 `;
 
-const SideSection =styled.div`
+const SideSection = styled.div`
   justify-items: center;
   margin: 3rem 5rem 0px 0rem;
-  padding:1rem;
-  width:"60%";
+  padding: 1rem;
+  width: '60%';
   height: 550px;
   border-radius: 20px 0px 0px 20px;
   background-color: #f6f6f9;
@@ -111,19 +128,19 @@ const SideSection =styled.div`
 
 const RightSection = styled.div`
   display: flex;
-  margin:3rem;
+  margin: 3rem;
   position: absolute;
-  left:45%;
+  left: 45%;
   background: white;
 `;
 
 const StyledH1 = styled.h1`
-    display: flex;
-    margin: 20px 10px 30px 30px;
-    padding: 3px;
-    font-size: 1.5rem;
-    font-weight: bold;
-    color: #fa4a0c;
+  display: flex;
+  margin: 20px 10px 30px 30px;
+  padding: 3px;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #fa4a0c;
 `;
 
 const StyledH2 = styled.h2`
@@ -134,19 +151,19 @@ const StyledH2 = styled.h2`
   text-align: center;
 `;
 
-const StyledDesc= styled.div`
-    display: block;
-    padding: 3px;
-    margin: 20px 10px 30px 30px;
-    font-weight: 500;
-    font-size:1.2rem;
+const StyledDesc = styled.div`
+  display: block;
+  padding: 3px;
+  margin: 20px 10px 30px 30px;
+  font-weight: 500;
+  font-size: 1.2rem;
 `;
 
-const Desc= styled.div`
-    display: block;
-    text-align: center;
-    font-weight: 500;
-    font-size:1.3rem;
+const Desc = styled.div`
+  display: block;
+  text-align: center;
+  font-weight: 500;
+  font-size: 1.3rem;
 `;
 
 const StyledList = styled.ul`
@@ -162,27 +179,27 @@ const StyledItem = styled.li`
   font-size: 1.2rem;
 `;
 const StyledBtn = styled.button`
-    padding: 40px;
-    padding-top:15px;
-    padding-bottom:15px;    
-    background: #FA4A0C;
-    border-radius: 25px;
-    margin: 30px;
-    font-weight: bold;
-    width:30%;
-    color: white;
-    box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
+  padding: 40px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  background: #fa4a0c;
+  border-radius: 25px;
+  margin: 30px;
+  font-weight: bold;
+  width: 30%;
+  color: white;
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
 `;
 
 const StyledQr = styled.div`
-  display:flex;
+  display: flex;
   margin: 3rem;
   padding: 130px;
   justify-content: center;
   align-items: center;
   width: 200px;
   height: 200px;
-  border: 5px solid #FA4A0C;
+  border: 5px solid #fa4a0c;
   overflow: hidden;
 `;
 

--- a/frontend/pages/resultmenu.tsx
+++ b/frontend/pages/resultmenu.tsx
@@ -1,15 +1,15 @@
-import { NextPage } from "next";
-import React, { useEffect, useState } from "react";
-import { AiOutlineShoppingCart } from "react-icons/ai";
-import styled from "styled-components";
-import axios from "axios";
-import { useRouter } from "next/router";
+import { NextPage } from 'next';
+import React, { useEffect, useState } from 'react';
+import { AiOutlineShoppingCart } from 'react-icons/ai';
+import styled from 'styled-components';
+import axios from 'axios';
+import { useRouter } from 'next/router';
 
-import SearchBar from "../components/SearchBar";
-import CategoryList from "../components/CategoryList";
-import FoodList from "../components/FoodList";
-import MenuBtmNav from "../components/MenuBtmNav";
-import CartModal from "../components/CartModal";
+import SearchBar from '../components/SearchBar';
+import CategoryList from '../components/CategoryList';
+import FoodList from '../components/FoodList';
+import MenuBtmNav from '../components/MenuBtmNav';
+import CartModal from '../components/CartModal';
 
 type CategoryType = {
   id: number;
@@ -29,18 +29,18 @@ const ResultMenu: NextPage = () => {
   const getCategoryUseMenuId = async (menuid: string | string[]) => {
     try {
       const response = await axios.get<CategoryType[]>(
-        "http://localhost:8080/category/get/menu/"+menuid,
+        'http://localhost:8080/category/get/menu/' + menuid,
         {
           headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-          }
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+          },
         }
       );
       console.log(response.data);
       setCategoryData(response.data);
     } catch (err) {
-      console.log("error", err);
+      console.log('error', err);
     }
   };
 

--- a/frontend/utils/useAsync.ts
+++ b/frontend/utils/useAsync.ts
@@ -1,0 +1,13 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useAsync = <T>(
+  asyncCallback: () => Promise<T>,
+  deps: any[] = []
+): [Error | null, () => void] => {
+  const [error, setError] = useState<Error | null>(null);
+  useEffect(() => {
+    asyncCallback().catch(setError);
+  }, deps);
+  const resetError = useCallback(() => setError((notUsed) => null), []);
+  return [error, resetError];
+};


### PR DESCRIPTION
개요 
- 사장님이 주문이 들어왔을때 주문을 확인할 수 있는 페이지에 대하여 마크업을 구현하였습니다. 

개발 내용
- dummy API를 통한 orderpage 마크업, 해당 api를 켜야지 마크업이 보입니다. yarn global add json-server 후 json-server ./data.json --port 4000 명령어를 프로젝트 최상단 디렉토리에서 실행해주세요.
- orderInfo 데이터 페치 훅과 함수를 따로 분리하여 관심사 분리 (이후 만약 orderbills에 대해 변경이 되어 서버쪽에서 추가적인 수정이 필요할 경우 일일히 컴포넌트에서 수정하지 않고 data/getOrderInfo.ts 만 수정해주면 됩니다.)
- 주말간 완성된 API를 통해 조금 더 구현할 예정입니다.

애로사항
- 테이블번호에 대해서 QR코드쪽 구현을 다음주 중으로 함께 개발해보겠습니다.

스크린샷
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/54930877/167263237-b76bd1e5-e383-453c-8509-94fa2dd598e6.png">
