### PR TITLE
Feature/mobile redirect #112 번 

### DIFF
--- a/frontend/components/LoginPage/LoginForm/LoginForm.tsx
+++ b/frontend/components/LoginPage/LoginForm/LoginForm.tsx
@@ -1,11 +1,14 @@
 import axios from 'axios';
 import React, { useState } from 'react';
 import Cookies from 'js-cookie';
+import { useRouter } from 'next/router';
 
 import { handleFormInputChange } from '../../../utils';
 import * as S from './LoginForm.style';
+
 function LoginForm() {
   const [formValue, setFormValue] = useState({});
+  const router = useRouter();
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {

--- a/frontend/components/LoginPage/LoginForm/LoginForm.tsx
+++ b/frontend/components/LoginPage/LoginForm/LoginForm.tsx
@@ -1,15 +1,11 @@
 import axios from 'axios';
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import Cookies from 'js-cookie';
-import { useRouter } from 'next/router';
 
 import { handleFormInputChange } from '../../../utils';
 import * as S from './LoginForm.style';
 function LoginForm() {
   const [formValue, setFormValue] = useState({});
-  const router = useRouter();
-
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {

--- a/frontend/components/PayBtn/PayBtn.tsx
+++ b/frontend/components/PayBtn/PayBtn.tsx
@@ -81,7 +81,7 @@ const PayBtn = ({ amount, itemList, tableNumber, ownerId }: Props) => {
       buyer_postcode: '06018', // 구매자 우편번호
       m_redirect_url: `http://34.64.187.105:3000${router.asPath}`, //결제 성공시 모바일 리다이렉션 주소
     };
-    IMP.request_pay(data);
+    IMP.request_pay(data, callback);
   };
 
   // @ts-ignore

--- a/frontend/components/PayBtn/PayBtn.tsx
+++ b/frontend/components/PayBtn/PayBtn.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import * as S from './style';
 import axios from 'axios';
+import { useRouter } from 'next/router';
 
 type CartData = {
   fileName: string;
@@ -17,6 +18,7 @@ type Props = {
   ownerId: string;
 };
 const PayBtn = ({ amount, itemList, tableNumber, ownerId }: Props) => {
+  const router = useRouter();
   useEffect(() => {
     const jquery = document.createElement('script');
     jquery.src = 'https://code.jquery.com/jquery-1.12.4.min.js';
@@ -77,6 +79,7 @@ const PayBtn = ({ amount, itemList, tableNumber, ownerId }: Props) => {
       buyer_email: 'example@example', // 구매자 이메일
       buyer_addr: '정왕동 661-16', // 구매자 주소
       buyer_postcode: '06018', // 구매자 우편번호
+      m_redirect_url: `http://34.64.187.105:3000${router.asPath}`, //결제 성공시 모바일 리다이렉션 주소
     };
     IMP.request_pay(data, callback);
   };

--- a/frontend/components/PayBtn/PayBtn.tsx
+++ b/frontend/components/PayBtn/PayBtn.tsx
@@ -81,7 +81,7 @@ const PayBtn = ({ amount, itemList, tableNumber, ownerId }: Props) => {
       buyer_postcode: '06018', // 구매자 우편번호
       m_redirect_url: `http://34.64.187.105:3000${router.asPath}`, //결제 성공시 모바일 리다이렉션 주소
     };
-    IMP.request_pay(data, callback);
+    IMP.request_pay(data);
   };
 
   // @ts-ignore
@@ -104,6 +104,18 @@ const PayBtn = ({ amount, itemList, tableNumber, ownerId }: Props) => {
       alert('결제 실패 : ' + error_msg);
     }
   };
+
+  //모바일 환경 결제 로직 추가
+  useEffect(() => {
+    if (typeof router.query.imp_success !== 'undefined') {
+      if (router.query.imp_success === 'true') {
+        void createOrder(itemList, String(router.query.imp_uid), amount);
+        alert('결제 성공');
+      } else {
+        alert('결제실패');
+      }
+    }
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
#112 번 이슈 반영

모바일 웹 환경에서 KG이니시스, NHN KCP, JTNet,토스페이먼츠 그리고 KICC는 PC 환경과는 다르게 각 PG사의 웹사이트로 리디렉션되어 결제가 진행됩니다. 이 경우, 결제가 완료되면 callback 함수가 실행되지 않으므로 IMP.request_pay함수의 param.m_redirect_url 파라미터에 리디렉션 될 URL을 설정하였습니다.

해당 리다이렉션 된 URL이 존재할 경우 성공 실패의 기준을 잡아 기존 콜백 함수의 로직이 실행되도록 변경하였습니다. 
코드가 모바일에서 테스트를 해봐야되서 배포를 해봐야 제대로 작동하는지 안하는지 알 수 있을 것 같습니다.

빠른 배포 부탁드립니당